### PR TITLE
Remove redundant _id handler

### DIFF
--- a/models/ActiveEntity.cfc
+++ b/models/ActiveEntity.cfc
@@ -141,9 +141,6 @@ component name="CFMongoActiveEntity" extends="cbmongodb.models.BaseDocumentServi
 	* @param string [value] 	If a valid operator is passed, the value would provide the operational comparison 
 	**/
 	any function where(string key,string operator='=',any value){
-		if(key == '_id'){
-			ARGUMENTS.value = getMongoUtil().newObjectIdFromId(ARGUMENTS.value);
-		}
 		if(!arrayFind(this.get_operators(),operator)){
 			return this.where(key=key,value=operator);
 		} else {


### PR DESCRIPTION
_id typing is already handled downstream in criteria()
