### PR TITLE
Remove EstablishHostInfo function from config

### DIFF
--- a/modules/cbmongodb/models/Mongo/Config.cfc
+++ b/modules/cbmongodb/models/Mongo/Config.cfc
@@ -43,8 +43,6 @@ component accessors="true" output="false" hint="Main configuration for MongoDB C
 		var MongoClientOptions = structKeyExists(configStruct,'clientOptions')?configStruct.clientOptions:{};
 
 
-		establishHostInfo();
-		
 		var auth = {
 			username:structKeyExists(hosts[1],'username')?hosts[1].username:"",
 			password:structKeyExists(hosts[1],'password')?hosts[1].password:""
@@ -77,15 +75,6 @@ component accessors="true" output="false" hint="Main configuration for MongoDB C
 
 	public function removeAllServers(){
 		variables.conf.servers.clear();
-		
-		return this;
-	}
-
-    public function establishHostInfo(){
-		// environment decisions can often be made from this information
-		var inetAddress = createObject( "java", "java.net.InetAddress");
-		variables.hostAddress = inetAddress.getLocalHost().getHostAddress();
-		variables.hostName = inetAddress.getLocalHost().getHostName();
 		
 		return this;
 	}


### PR DESCRIPTION
Removing this function because the variables that it sets aren't used anywhere in the project. They are also unused in the older cfMongoDB project -- so I assumed this function was just legacy code that was safe to remove.

The motivation for this PR is that calls to createObject( "java", "java.net.InetAddress").getLocalHost() throw exceptions in our commandbox docker containers when they're running in Docker Swarm. We still need to get to the bottom of that, however, eliminating the code removes the temporary roadblock for us.
